### PR TITLE
Remove colon from Basic scheme in generated HTTP Authorization header

### DIFF
--- a/ocpp-j-api/src/main/scala/com/thenewmotion/ocpp/json/api/client/SimpleClientWebSocketComponent.scala
+++ b/ocpp-j-api/src/main/scala/com/thenewmotion/ocpp/json/api/client/SimpleClientWebSocketComponent.scala
@@ -30,7 +30,7 @@ trait SimpleClientWebSocketComponent extends WebSocketComponent {
     private val actualUri = uriWithChargerId(uri, chargerId)
 
     private val headers: java.util.Map[String, String] =
-      authPassword.map(password => authHeader -> s"Basic: ${toBase64String(chargerId, password)}")
+      authPassword.map(password => authHeader -> s"Basic ${toBase64String(chargerId, password)}")
        .toMap.asJava
 
     import org.java_websocket.client.WebSocketClient


### PR DESCRIPTION
Per [RFC 7617](https://tools.ietf.org/html/rfc7617#section-2) the HTTP Authorization scheme for basic authentication is `Basic`, but SimpleClientWebSocketComponent is writing the scheme as `Basic:` (with a colon). I discovered this problem when trying to use the [docile-charge-point](https://github.com/NewMotion/docile-charge-point) simulator against a Central System that requires basic authentication.